### PR TITLE
click coords bug fixed

### DIFF
--- a/js/GridView.js
+++ b/js/GridView.js
@@ -50,8 +50,10 @@ function GridView(canvas, userConfig) {
 //      console.log(canvas.offsetLeft)
 //      console.log(canvas.offsetTop)
 
-        x -= canvas.offsetLeft;
-        y -= canvas.offsetTop;
+//        x -= canvas.offsetLeft;
+//        y -= canvas.offsetTop;
+        x -= canvas.getBoundingClientRect().left;
+        y -= canvas.getBoundingClientRect().top;
 
 
         // ajust for border

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -1,0 +1,2 @@
+;(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({},{},[])
+;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Reusable grid model and grid canvas view for 2D board games.",
   "main": "js/main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "grunt test",
+    "start": "grunt watch"
   },
   "repository": {
     "type": "git",
@@ -22,9 +23,10 @@
     "url": "https://github.com/marushkevych/game-grid/issues"
   },
   "devDependencies": {
-    "grunt": "~0.4.4",
-    "grunt-contrib-jasmine": "~0.6.3",
-    "grunt-watchify": "~0.1.0"
+    "grunt": "^0.4.4",
+    "grunt-contrib-jasmine": "^0.9.2",
+    "grunt-contrib-uglify": "^3.0.1",
+    "grunt-watchify": "^0.1.0"
   },
   "dependencies": {
     "underscore": "~1.6.0"

--- a/spec/GridViewSpec.js
+++ b/spec/GridViewSpec.js
@@ -10,6 +10,9 @@ describe("GridView", function() {
             eventHandlers: {},
             addEventListener: function(event, handler){
                 this.eventHandlers[event] = handler;
+            },
+            getBoundingClientRect: function() {
+                return { left: this.offsetLeft, top: this.offsetTop }
             }
         };
     });


### PR DESCRIPTION
Hi.
I wanted to use this lib in my project, but came across bug. In cell click handler you use **canvas.offsetLeft** and **canvas.offsetTop**, but those give you back offset to closest offset parent while click coords are relative to viewport. In my case canvas was nested, so click coordinates were calculated with error. I changed this code to use 'getClientBoundingRect' and it works ok now, I also updated tests and npm packages in order to run test suite.
Can you review my code and merge it (if it is ok) so I can use updated version in npm? Please tell me if you will not find it suitable, so I can fix this bug on my side.